### PR TITLE
BaseEvent implements the Serializable interface, which is deprecated

### DIFF
--- a/src/Events/BaseEvent.php
+++ b/src/Events/BaseEvent.php
@@ -16,9 +16,9 @@ use Workflow;
  */
 abstract class BaseEvent extends Event implements Serializable
 {
-    public function serialize()
+    public function __serialize(): array
     {
-        return serialize([
+        return [
             'base_event_class' => get_class($this),
             'subject' => $this->getSubject(),
             'marking' => $this->getMarking(),
@@ -26,18 +26,26 @@ abstract class BaseEvent extends Event implements Serializable
             'workflow' => [
                 'name' => $this->getWorkflowName(),
             ],
-        ]);
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->subject = $data['subject'];
+        $this->marking = $data['marking'];
+        $this->transition = $data['transition'] ?? null;
+        $workflowName = $data['workflow']['name'] ?? null;
+        $this->workflow = Workflow::get($this->subject, $workflowName);
+    }
+
+    public function serialize()
+    {
+        return serialize($this->__serialize());
     }
 
     public function unserialize($serialized)
     {
-        $unserialized = unserialize($serialized);
-
-        $this->subject = $unserialized['subject'];
-        $this->marking = $unserialized['marking'];
-        $this->transition = $unserialized['transition'] ?? null;
-        $workflowName = $unserialized['workflow']['name'] ?? null;
-        $this->workflow = Workflow::get($this->subject, $workflowName);
+        $this->__unserialize(unserialize($serialized));
     }
 
     /**


### PR DESCRIPTION
Deprecated: ZeroDaHero\LaravelWorkflow\Events\AnnounceEvent implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)

runtime [php 8.1.2]
laravel components [9]

https://www.php.net/manual/en/migration81.deprecated.php